### PR TITLE
fix: externalize react-dom subpaths so hedgehog mode loads on React 18 hosts

### DIFF
--- a/hedgehog-mode/package.json
+++ b/hedgehog-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@posthog/hedgehog-mode",
-  "version": "0.0.51",
+  "version": "0.0.52",
   "description": "hedgehog mode",
   "type": "module",
   "main": "dist/index.js",

--- a/hedgehog-mode/vite.config.ts
+++ b/hedgehog-mode/vite.config.ts
@@ -14,7 +14,16 @@ export default defineConfig(({ mode }) => {
       },
       sourcemap: true,
       rollupOptions: {
-        external: ["react", "react-dom"],
+        // Externalize React and ALL of its subpaths (react-dom/server,
+        // react-dom/client, react/jsx-runtime, …). Exact-string externals only
+        // match the bare specifier, so a subpath like `react-dom/server` —
+        // which `react-shadow` imports — would otherwise get bundled. Inlining
+        // React's own renderer is fatal: the bundled copy reaches into React's
+        // internal dispatcher, and if its version doesn't match the host app's
+        // React it throws at module-eval (e.g. a React 19 build of
+        // `react-dom/server` crashes on a React 18 host). Always defer to the
+        // host's React via the peer dependency.
+        external: [/^react($|\/)/, /^react-dom($|\/)/],
         output: {
           globals: {
             react: "React",


### PR DESCRIPTION
## Problem

Hedgehog mode silently fails to load on React 18 sites (e.g. **posthog.com**) since **0.0.49**. Nothing renders — no canvas, no shadow root — and the console shows:

```
TypeError: Cannot read properties of undefined (reading 'd')
  at Module ../@posthog/hedgehog-mode/dist/react-shadow.esm-*.js   ← throws at module-eval
```

## Root cause

The vite build externalized only the **bare** specifiers `"react"` and `"react-dom"`. Rollup externals are exact-match, so `react-dom/server` — which `react-shadow` imports — was **not** externalized and got **bundled** into the react-shadow chunk.

Since 0.0.49 (the React 19 switch, #23) that inlined copy is **React 19's** `react-dom/server`, whose module-eval code reads React's DOM internal dispatcher (`ReactDOM.__DOM_INTERNALS….d`). On a host running **React 18** that internal is `undefined`, so loading the chunk throws. The throw rejects the lazy `import("react-shadow")`, leaving `useShadowDiv()` permanently `null`, so `HedgehogModeRenderer` renders nothing.

## Fix

Externalize **all** react/react-dom subpaths via regex, so React's renderer is always provided by the host app and version-matched:

```ts
external: [/^react($|\/)/, /^react-dom($|\/)/]   // was: ["react", "react-dom"]
```

## Verification (against real React 18.3.1 site — posthog.com)

- react-shadow chunk: **863 kB → 31 kB**; `react-dom/server` is now an external import; zero React-19-internals strings remain in the bundle.
- Headless-browser repro on posthog.com `/?hedgehog_mode=true`: `#hedgehog-mode-root` gets a shadow root, `.GameContainer` mounts, and (with WebGL) the pixi canvases render. **No runtime error.**
- `pnpm lint` passes (pre-existing warnings only). Pre-existing `helloWorld` test failures are unrelated (fail on clean `main` too).

Bumps version to **0.0.52** so the CD workflow publishes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)