### PR TITLE
fix: externalize pixi.js so consumers share one instance

### DIFF
--- a/hedgehog-mode/package.json
+++ b/hedgehog-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@posthog/hedgehog-mode",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "hedgehog mode",
   "type": "module",
   "main": "dist/index.js",

--- a/hedgehog-mode/vite.config.ts
+++ b/hedgehog-mode/vite.config.ts
@@ -23,7 +23,15 @@ export default defineConfig(({ mode }) => {
         // React it throws at module-eval (e.g. a React 19 build of
         // `react-dom/server` crashes on a React 18 host). Always defer to the
         // host's React via the peer dependency.
-        external: [/^react($|\/)/, /^react-dom($|\/)/],
+        //
+        // pixi.js (and subpaths like pixi.js/unsafe-eval) is externalized for
+        // the same single-instance reason: pixi is already a dependency, so
+        // consumers resolve one shared copy from their tree rather than a ~1.3MB
+        // duplicate welded into this bundle. Inlining it also makes pixi
+        // unreachable — consumers can't apply `pixi.js/unsafe-eval` (needed under
+        // strict-CSP / MV3 hosts that forbid `new Function`) or otherwise
+        // configure the renderer, because the patch can't see the bundled copy.
+        external: [/^react($|\/)/, /^react-dom($|\/)/, /^pixi\.js($|\/)/],
         output: {
           globals: {
             react: "React",
@@ -34,10 +42,10 @@ export default defineConfig(({ mode }) => {
     },
     resolve: {
       alias: { src: resolve("src/") },
-      dedupe: ["react", "react-dom"],
+      dedupe: ["react", "react-dom", "pixi.js"],
     },
     optimizeDeps: {
-      include: ["react", "react-dom"],
+      include: ["react", "react-dom", "pixi.js"],
       exclude: ["@posthog/hedgehog-mode"],
     },
     test: {

--- a/hedgehog-mode/vite.config.ts
+++ b/hedgehog-mode/vite.config.ts
@@ -24,13 +24,9 @@ export default defineConfig(({ mode }) => {
         // `react-dom/server` crashes on a React 18 host). Always defer to the
         // host's React via the peer dependency.
         //
-        // pixi.js (and subpaths like pixi.js/unsafe-eval) is externalized for
-        // the same single-instance reason: pixi is already a dependency, so
-        // consumers resolve one shared copy from their tree rather than a ~1.3MB
-        // duplicate welded into this bundle. Inlining it also makes pixi
-        // unreachable — consumers can't apply `pixi.js/unsafe-eval` (needed under
-        // strict-CSP / MV3 hosts that forbid `new Function`) or otherwise
-        // configure the renderer, because the patch can't see the bundled copy.
+        // Externalize pixi.js for the same single-instance reason: it's already a
+        // consumer dependency, so they share one copy (~1.3MB) and can still patch it
+        // (e.g. pixi.js/unsafe-eval, required under strict-CSP/MV3 hosts that ban new Function).
         external: [/^react($|\/)/, /^react-dom($|\/)/, /^pixi\.js($|\/)/],
         output: {
           globals: {


### PR DESCRIPTION
## Problem

The published dist welds pixi.js **inline** (~1.3 MB) instead of importing it, even though pixi is already a declared `dependency`. Consequences:

- Every consumer ships a duplicate pixi (declared dep **and** an inlined copy).
- The bundled pixi is **unreachable**, so consumers can't apply [`pixi.js/unsafe-eval`](https://pixijs.com/8.x/guides/migrations/v8#unsafe-eval) — required where `new Function` is blocked (strict-CSP pages, MV3 browser-extension content scripts) — or configure the renderer (e.g. `loadTextures.config.preferWorkers`). This makes it impossible to run hedgehog mode as a browser extension on arbitrary sites.

## Changes

- Externalize `pixi.js` and its subpaths in the vite build (`/^pixi\.js($|\/)/`), mirroring the react / react-dom treatment from #28.
- Add `pixi.js` to `resolve.dedupe` and `optimizeDeps.include`.
- pixi stays a regular `dependency`, so consumers auto-resolve a single shared copy — **no consumer action required**.
- Main chunk drops ~1.27 MB → ~606 KB; the dist now imports `Application, Assets, Spritesheet, AnimatedSprite, Graphics, ColorMatrixFilter, Sprite` from `pixi.js`.

## How did you test this code?

- `pnpm build` succeeds; verified the dist no longer inlines pixi (`_unsafeEvalCheck` / `preferWorkers` gone) and imports `pixi.js` bare.
- `pnpm lint` clean — no new warnings. Pre-existing scaffold test failures (`helloWorld`) are unaffected.
- Packed the build and installed it into a clean consumer project (single react/pixi tree). With `import "pixi.js/unsafe-eval"` + `loadTextures.config.preferWorkers = false`, a hedgehog renders under a strict CSP (`script-src 'self'`, blocking both eval and blob workers) with no errors — the exact MV3 / extension scenario that's impossible with the inlined build.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*