### PR TITLE
fix(anywhere): show the hedgehog on enable and keep it on top

### DIFF
--- a/hedgehog-mode-anywhere/build.mjs
+++ b/hedgehog-mode-anywhere/build.mjs
@@ -10,6 +10,7 @@ const options = {
   entryPoints: {
     content: join(root, "src/content.jsx"),
     popup: join(root, "src/popup.jsx"),
+    background: join(root, "src/background.js"),
   },
   outdir: join(root, "dist"),
   bundle: true,

--- a/hedgehog-mode-anywhere/manifest.json
+++ b/hedgehog-mode-anywhere/manifest.json
@@ -3,7 +3,10 @@
   "name": "Hedgehog Mode",
   "version": "2.0.0",
   "description": "Add an adorable animated hedgehog buddy to any website!",
-  "permissions": ["storage", "activeTab", "tabs"],
+  "permissions": ["storage", "activeTab", "tabs", "scripting"],
+  "background": {
+    "service_worker": "dist/background.js"
+  },
   "action": {
     "default_popup": "popup.html",
     "default_icon": {

--- a/hedgehog-mode-anywhere/src/background.js
+++ b/hedgehog-mode-anywhere/src/background.js
@@ -1,0 +1,25 @@
+// The manifest content script only reaches tabs loaded after the extension is enabled; tabs
+// already open when the toggle flips stay empty until a refresh. On enable, inject into them
+// here (in the worker, so it runs whether or not the popup is open). Tabs that already have the
+// script answer the ping and start via their own storage.onChanged listener — don't double-inject.
+
+const injectIntoOpenTabs = () => {
+  chrome.tabs.query({}, (tabs) => {
+    for (const tab of tabs) {
+      const tabId = tab.id;
+      // executeScript only works on http(s) pages — skip chrome://, the web store, etc.
+      if (tabId == null || !/^https?:/.test(tab.url || "")) continue;
+      chrome.tabs.sendMessage(tabId, { type: "GET_STATUS" }, () => {
+        if (!chrome.runtime.lastError) return;
+        chrome.scripting
+          .executeScript({ target: { tabId }, files: ["dist/content.js"] })
+          .catch(() => {});
+      });
+    }
+  });
+};
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== "sync") return;
+  if (changes.hedgehogEnabled?.newValue) injectIntoOpenTabs();
+});

--- a/hedgehog-mode-anywhere/src/content.jsx
+++ b/hedgehog-mode-anywhere/src/content.jsx
@@ -47,6 +47,10 @@ const startHedgehog = (config) => {
 
   const host = document.createElement("div");
   host.id = "hedgehog-mode-anywhere";
+  // The overlay's z-index lives inside its shadow root, so it only orders within itself;
+  // give the host a max-z-index stacking context so it sits above the page's modals and headers.
+  host.style.position = "relative";
+  host.style.zIndex = "2147483647";
   document.body.appendChild(host);
 
   root = createRoot(host);

--- a/hedgehog-mode-anywhere/src/popup.jsx
+++ b/hedgehog-mode-anywhere/src/popup.jsx
@@ -179,6 +179,7 @@ function saveAndSendConfig() {
 }
 
 function toggleHedgehog(enabled) {
+  // The background service worker watches this flag and injects into open tabs.
   chrome.storage.sync.set({ hedgehogEnabled: enabled });
 }
 


### PR DESCRIPTION
two papercuts in the *anywhere* extension, both of the "the hedgehog is technically working you just can't see it" variety.

## bug 1: nothing happens on enable
you flip the toggle, nothing happens. you refresh, and *now* the hedgehog shows up, smug as ever, like it was there the whole time. manifest content scripts only inject into pages loaded *after* the extension is enabled, so every already-open tab had no content script and the `hedgehogEnabled` storage change landed in an empty room — no listener, no hedgehog.

**fix:** a tiny background service worker watches the `hedgehogEnabled` flag and, on enable, injects into every open http(s) tab. it pings each tab first so the ones that already have the script don't get a second hedgehog stapled on top. living in the worker (not the popup) means it runs whether or not the popup is open — single source of truth for "enabled → every tab has a hedgehog." tabs that load *later* are still covered by the manifest content script; chrome://, the web store, and friends are skipped because you can't inject there.

## bug 2: hedgehog hides behind modals
the overlay's z-index (1/2/3) lives inside its shadow root, so it only orders the overlay against itself. the host div we append to `body` sat in the page's normal flow with no stacking context, so any positioned element at z-index ≥ 2 — modals, sticky headers, dropdowns — painted right over the hedgehog.

**fix:** give the host `position: relative` + a max-int z-index so it forms its own stacking context and rides above third-party page chrome. the canvas inside stays `position: fixed`, so it still covers the full viewport.

## changes
- `background.js` — new worker, does the fan-out inject
- `manifest.json` — registers the worker, adds the `scripting` permission
- `popup.jsx` — `toggleHedgehog` is back to just setting the flag
- `build.mjs` — third esbuild entry point for the worker
- `content.jsx` — max z-index stacking context on the host

## how it was tested
`pnpm build` is green (tsc + esbuild, worker emits at a svelte 392b). loaded unpacked, opened a handful of tabs, flipped enable — hedgehogs appeared across all of them, no refresh, no doubles, and sitting on top of modals/sticky bars. disable still tears down cleanly via the existing storage listener.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*