### PR TITLE
fix(anywhere): keep the hog off the top edge + persist state in chrome.storage

### DIFF
--- a/hedgehog-mode-anywhere/CHANGELOG.md
+++ b/hedgehog-mode-anywhere/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## 2026-07-21
 
 - Keep the hedgehog off the top strip of the window: platform discovery now ignores the top 100px, so he no longer perches on sticky headers/nav bars where he's clipped against the top edge (`platforms.viewportPadding.top`)
-- Persist engine state (including in-page customization) via `chrome.storage.sync` instead of the host page's `localStorage`, so it survives navigation across origins and syncs across windows and sessions (needs `@posthog/hedgehog-mode`'s new `onStateChange` config hook)
+- Persist engine state (including in-page customization) via `chrome.storage.sync` instead of the host page's `localStorage`, so it survives navigation across origins and syncs across windows and sessions (via `@posthog/hedgehog-mode@0.0.54`'s new `onStateChange` config hook)
 - Replaced the hand-built popup customization grid with the engine's own `HedgehogCustomization` component (the same UI as the in-page "Customize me!" panel), so the popup and in-page editing stay identical for free — and gained the friends section. The extension shell keeps the global-enable, per-site-disable, and interactions toggles
 - Added a friend hedgehog? They now persist and sync like the main one
-- Engine change: `HedgehogCustomization` takes `assetsUrl` directly instead of a whole `HedgeHogMode` instance, so the UI can render without a running game (`game` still accepted, deprecated)
+- Engine change (`@posthog/hedgehog-mode@0.0.54`): `HedgehogCustomization` takes `assetsUrl` directly instead of a whole `HedgeHogMode` instance, so the UI can render without a running game (`game` still accepted, deprecated)
 
 ## 2026-06-24
 

--- a/hedgehog-mode-anywhere/CHANGELOG.md
+++ b/hedgehog-mode-anywhere/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-07-21
+
+- Keep the hedgehog off the top strip of the window: platform discovery now ignores the top 100px, so he no longer perches on sticky headers/nav bars where he's clipped against the top edge (`platforms.viewportPadding.top`)
+- Persist engine state (including in-page customization) via `chrome.storage.sync` instead of the host page's `localStorage`, so it survives navigation across origins and syncs across windows and sessions (needs `@posthog/hedgehog-mode`'s new `onStateChange` config hook)
+
 ## 2026-06-24
 
 - Use `@posthog/hedgehog-mode@0.0.53`, which externalizes pixi.js for MV3 / strict-CSP compatibility ([PostHog/hedgehog-mode#30](https://github.com/PostHog/hedgehog-mode/pull/30))

--- a/hedgehog-mode-anywhere/CHANGELOG.md
+++ b/hedgehog-mode-anywhere/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Keep the hedgehog off the top strip of the window: platform discovery now ignores the top 100px, so he no longer perches on sticky headers/nav bars where he's clipped against the top edge (`platforms.viewportPadding.top`)
 - Persist engine state (including in-page customization) via `chrome.storage.sync` instead of the host page's `localStorage`, so it survives navigation across origins and syncs across windows and sessions (needs `@posthog/hedgehog-mode`'s new `onStateChange` config hook)
+- Replaced the hand-built popup customization grid with the engine's own `HedgehogCustomization` component (the same UI as the in-page "Customize me!" panel), so the popup and in-page editing stay identical for free — and gained the friends section. The extension shell keeps the global-enable, per-site-disable, and interactions toggles
+- Added a friend hedgehog? They now persist and sync like the main one
+- Engine change: `HedgehogCustomization` takes `assetsUrl` directly instead of a whole `HedgeHogMode` instance, so the UI can render without a running game (`game` still accepted, deprecated)
 
 ## 2026-06-24
 

--- a/hedgehog-mode-anywhere/README.md
+++ b/hedgehog-mode-anywhere/README.md
@@ -37,6 +37,45 @@ This produces `dist/content.js`, `dist/popup.js`, and copies the hedgehog sprite
 
 > The bundled `@posthog/hedgehog-mode` must keep pixi.js externalized ([PostHog/hedgehog-mode#30](https://github.com/PostHog/hedgehog-mode/pull/30)). Builds that inline pixi.js use a `new Function` shader path that MV3 content scripts forbid and that the extension can't patch. With pixi external, `src/content.jsx` patches the single shared pixi.js for eval-free shaders and main-thread texture loading, so the hedgehog runs on any page even under a strict Content-Security-Policy.
 
+## 🧪 Developing & testing locally
+
+There are two ways in, depending on what you're changing.
+
+### The customization UI, without a browser extension
+
+The popup renders the engine's own `HedgehogCustomization` component — the same one the playground's `/config` page uses — so the playground is the fastest way to iterate on it:
+
+```bash
+pnpm dev         # engine watcher + playground on http://localhost:8002
+```
+
+- **http://localhost:8002/config** — the customization panel (skins, colors, accessories, friends, options).
+- **http://localhost:8002/** — the live hedgehog, for physics and click/drag.
+
+Leave `pnpm dev` running while you work on the extension too: it keeps the engine's `dist/` fresh, which the extension bundles.
+
+### The extension itself
+
+Rebuild on change alongside a running `pnpm dev`, then reload the unpacked extension:
+
+```bash
+pnpm --dir hedgehog-mode-anywhere watch
+```
+
+Load it via [Installation](#-installation) below. After each rebuild, click the **reload** ↻ on the extension's card in `chrome://extensions`, then refresh the page you're testing (the content script injects at `document_end`, and only on `http(s)` pages — not `chrome://` or the web store).
+
+What to poke at:
+
+- **Platform inset** — enable the hedgehog on a site with a sticky header/nav bar; he should stay off the top strip of the window instead of perching there out of sight. Press **`ctrl+d` five times** on the page to toggle the matter.js debug renderer and see the platform bodies (none are created in the top 100px).
+- **Persistence & sync** — customize the hedgehog, then navigate to a _different_ domain: the look survives. Open a second window and change something; the other updates within a second. Settings live in `chrome.storage.sync` (shared across tabs, windows, sessions, and signed-in browsers), not the page's `localStorage`.
+- **Popup + in-page parity** — the popup and the in-page "Customize me!" panel are the same component, so a change in one shows up in the other. Add a friend from the popup and it appears (and persists) without a reload.
+
+Reset all state from the extension's service-worker console (`chrome://extensions` → the extension → **service worker**):
+
+```js
+chrome.storage.sync.clear();
+```
+
 ## 📦 Installation
 
 ### Chrome / Brave / Edge (Chromium browsers)

--- a/hedgehog-mode-anywhere/api-contract.ts
+++ b/hedgehog-mode-anywhere/api-contract.ts
@@ -7,10 +7,8 @@
 import type { ComponentProps } from "react";
 import {
   HedgehogModeRenderer,
-  StaticHedgehog,
-  HedgehogActorSkinOptions,
-  HedgehogActorColorOptions,
-  HedgehogActorAccessories,
+  HedgehogModeRendererContent,
+  HedgehogCustomization,
 } from "@posthog/hedgehog-mode";
 
 // content.jsx: <HedgehogModeRenderer config={...} onGameReady={...} />
@@ -22,25 +20,33 @@ const _config: RendererProps["config"] = {
   onStateChange: (state) => void state.options,
 };
 const _onReady: NonNullable<RendererProps["onGameReady"]> = (game) => {
-  // content.jsx drives the actor returned here; pin the members it calls.
+  // content.jsx drives the game returned here; pin the members it calls.
+  game.stateManager?.setHedgehog({ id: "player", player: true });
   const actor = game.getPlayableHedgehog();
   if (!actor) return;
-  actor.updateOptions(actor.options);
   actor.updateSprite(actor.currentSprite ?? "idle");
   actor.setOnFire();
+  void actor.options;
 };
 
-// popup.jsx: <StaticHedgehog options={...} assetsUrl={...} size="100%" /> and the option lists.
-type StaticProps = ComponentProps<typeof StaticHedgehog>;
-const _static: Pick<StaticProps, "options" | "assetsUrl" | "size"> = {
-  options: { id: "preview" },
+// popup.jsx renders the library's own customization UI inside HedgehogModeRendererContent
+// (for the engine's shadow-root styles) instead of a hand-rolled grid.
+type CustomizationProps = ComponentProps<typeof HedgehogCustomization>;
+const _customization: Pick<
+  CustomizationProps,
+  "config" | "setConfig" | "assetsUrl"
+> = {
+  config: { id: "player", player: true },
+  setConfig: (config) => void config,
   assetsUrl: "",
-  size: "100%",
 };
-HedgehogActorSkinOptions.map((skin) => skin);
-HedgehogActorColorOptions.map((color) => color);
-Object.values(HedgehogActorAccessories).map((accessory) => accessory.group);
+type ContentProps = ComponentProps<typeof HedgehogModeRendererContent>;
+const _content: Pick<ContentProps, "id" | "theme"> = {
+  id: "hedgehog-customization",
+  theme: "dark",
+};
 
 void _config;
 void _onReady;
-void _static;
+void _customization;
+void _content;

--- a/hedgehog-mode-anywhere/api-contract.ts
+++ b/hedgehog-mode-anywhere/api-contract.ts
@@ -17,8 +17,9 @@ import {
 type RendererProps = ComponentProps<typeof HedgehogModeRenderer>;
 const _config: RendererProps["config"] = {
   assetsUrl: "",
-  platforms: { selector: "" },
+  platforms: { selector: "", viewportPadding: { top: 100 } },
   state: { options: { id: "player", player: true } },
+  onStateChange: (state) => void state.options,
 };
 const _onReady: NonNullable<RendererProps["onGameReady"]> = (game) => {
   // content.jsx drives the actor returned here; pin the members it calls.

--- a/hedgehog-mode-anywhere/manifest.json
+++ b/hedgehog-mode-anywhere/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Hedgehog Mode",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Add an adorable animated hedgehog buddy to any website!",
   "permissions": ["storage", "activeTab", "tabs", "scripting"],
   "background": {

--- a/hedgehog-mode-anywhere/package.json
+++ b/hedgehog-mode-anywhere/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hedgehog-mode-anywhere",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "private": true,
   "description": "Add an adorable animated hedgehog buddy to any website, powered by PostHog's hedgehog-mode engine.",
   "type": "module",

--- a/hedgehog-mode-anywhere/popup.html
+++ b/hedgehog-mode-anywhere/popup.html
@@ -111,50 +111,11 @@
         transform: translateX(16px);
       }
 
-      .preview-card {
-        display: flex;
-        align-items: flex-start;
-        gap: 16px;
-        padding: 16px;
-        background: #2c2f3e;
-        border-radius: 12px;
-        margin-bottom: 20px;
-      }
-
-      .preview-hedgehog {
-        width: 80px;
-        height: 80px;
-        position: relative;
-        flex-shrink: 0;
-      }
-
-      .preview-text h2 {
-        font-size: 16px;
-        font-weight: 600;
-        margin-bottom: 6px;
-      }
-
-      .preview-text p {
-        font-size: 13px;
-        color: #9ba0b0;
-        line-height: 1.5;
-      }
-
-      .section {
-        margin-bottom: 20px;
-      }
-
-      .section-title {
-        font-size: 14px;
-        font-weight: 600;
-        color: #fff;
-        margin-bottom: 12px;
-      }
-
       .options-toggles {
         display: flex;
         flex-wrap: wrap;
         gap: 10px;
+        margin-bottom: 16px;
       }
 
       .option-toggle {
@@ -187,45 +148,8 @@
         transform: translateX(14px);
       }
 
-      .preview-grid {
-        display: grid;
-        grid-template-columns: repeat(7, 1fr);
-        gap: 8px;
-      }
-
-      .preview-btn {
-        width: 100%;
-        aspect-ratio: 1;
-        border: 2px solid transparent;
-        border-radius: 8px;
-        background: transparent;
-        cursor: pointer;
-        padding: 0;
-        transition: all 0.2s;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        position: relative;
-        overflow: hidden;
-      }
-
-      .preview-btn:hover {
-        background: #3c4152;
-      }
-
-      .preview-btn:focus-visible {
-        outline: 2px solid #d4a019;
-        outline-offset: 2px;
-      }
-
-      .preview-btn.active {
-        border-color: #d4a019;
-      }
-
-      .preview-btn .sprite-container {
-        width: 100%;
-        height: 100%;
-        position: relative;
+      #hedgehog-customization {
+        display: block;
       }
 
       .footer {
@@ -248,134 +172,7 @@
     </style>
   </head>
   <body>
-    <div class="header">
-      <h1>Hedgehog mode</h1>
-    </div>
-
-    <div class="top-toggles">
-      <label class="toggle-pill">
-        <span>Enabled hedgehog mode</span>
-        <span class="toggle">
-          <input
-            type="checkbox"
-            id="enableToggle"
-            aria-label="Enable hedgehog mode"
-          />
-          <span class="toggle-slider"></span>
-        </span>
-      </label>
-      <label class="toggle-pill">
-        <span id="siteToggleLabel">Disable on this site</span>
-        <span class="toggle">
-          <input
-            type="checkbox"
-            id="siteToggle"
-            aria-label="Disable on this site"
-          />
-          <span class="toggle-slider"></span>
-        </span>
-      </label>
-    </div>
-
-    <div class="preview-card">
-      <div class="preview-hedgehog" id="previewHedgehog"></div>
-      <div class="preview-text">
-        <h2>Hi, I'm Max!</h2>
-        <p>
-          Don't mind me. I'm just here to keep you company.<br />
-          You can move me around by clicking and dragging or control me with
-          WASD / arrow keys.
-        </p>
-      </div>
-    </div>
-
-    <div class="section">
-      <div class="section-title">Options</div>
-      <div class="options-toggles">
-        <label class="option-toggle">
-          <span>Walk around freely</span>
-          <span class="toggle">
-            <input
-              type="checkbox"
-              id="walkingEnabled"
-              checked
-              aria-label="Walk around freely"
-            />
-            <span class="toggle-slider"></span>
-          </span>
-        </label>
-        <label class="option-toggle">
-          <span>Interact with elements</span>
-          <span class="toggle">
-            <input
-              type="checkbox"
-              id="interactionsEnabled"
-              checked
-              aria-label="Interact with elements"
-            />
-            <span class="toggle-slider"></span>
-          </span>
-        </label>
-        <label class="option-toggle">
-          <span>Keyboard controls (WASD / arrow keys)</span>
-          <span class="toggle">
-            <input
-              type="checkbox"
-              id="controlsEnabled"
-              checked
-              aria-label="Keyboard controls"
-            />
-            <span class="toggle-slider"></span>
-          </span>
-        </label>
-      </div>
-    </div>
-
-    <div class="section">
-      <div class="section-title">Skins and colors</div>
-      <div
-        class="preview-grid"
-        id="skinsGrid"
-        role="group"
-        aria-label="Skins and colors"
-      ></div>
-    </div>
-
-    <div class="section">
-      <div class="section-title">Headwear</div>
-      <div
-        class="preview-grid"
-        id="headwearGrid"
-        role="group"
-        aria-label="Headwear"
-      ></div>
-    </div>
-
-    <div class="section">
-      <div class="section-title">Eyewear</div>
-      <div
-        class="preview-grid"
-        id="eyewearGrid"
-        role="group"
-        aria-label="Eyewear"
-      ></div>
-    </div>
-
-    <div class="section">
-      <div class="section-title">Other</div>
-      <div
-        class="preview-grid"
-        id="otherGrid"
-        role="group"
-        aria-label="Other accessories"
-      ></div>
-    </div>
-
-    <div class="footer">
-      Made with love by
-      <a href="https://posthog.com" target="_blank">PostHog</a>
-    </div>
-
+    <div id="root"></div>
     <script src="dist/popup.js"></script>
   </body>
 </html>

--- a/hedgehog-mode-anywhere/src/content.jsx
+++ b/hedgehog-mode-anywhere/src/content.jsx
@@ -1,6 +1,6 @@
 // Content script: drives the hedgehog-mode engine on the page.
-// The popup owns customization and talks to us over chrome.runtime messages;
-// global enable/disable + per-site state live in chrome.storage.sync.
+// All config — customization, global enable/disable, per-site state — lives in
+// chrome.storage.sync; the popup writes it and every tab reacts via storage events.
 //
 // Two pixi.js behaviours break under MV3 / strict-CSP pages and are neutralised before any
 // renderer is created:
@@ -12,6 +12,7 @@ import "pixi.js/unsafe-eval";
 import { loadTextures } from "pixi.js";
 import { createRoot } from "react-dom/client";
 import { HedgehogModeRenderer } from "@posthog/hedgehog-mode";
+import { toActorOptions, fromActorOptions } from "./hedgehog-config";
 
 loadTextures.config.preferWorkers = false;
 
@@ -24,25 +25,6 @@ const PLATFORM_SELECTOR =
 // the top edge of the window where he's clipped and effectively invisible. Keep his world
 // starting a bit below the fold. (See HedgehogModeConfig.platforms.viewportPadding.)
 const PLATFORM_TOP_INSET = 100;
-
-// Stored config keys map onto the library's HedgehogActorOptions.
-const toActorOptions = (config = {}) => ({
-  skin: config.skin || "default",
-  color: config.color || null,
-  accessories: config.accessories || [],
-  ai_enabled: config.walking_enabled ?? true,
-  interactions_enabled: config.interactions_enabled ?? true,
-  controls_enabled: config.controls_enabled ?? true,
-});
-
-const fromActorOptions = (options) => ({
-  skin: options.skin || "default",
-  color: options.color || null,
-  accessories: options.accessories || [],
-  walking_enabled: options.ai_enabled ?? true,
-  interactions_enabled: options.interactions_enabled ?? true,
-  controls_enabled: options.controls_enabled ?? true,
-});
 
 // The engine persists its state through chrome.storage.sync (below) instead of writing to
 // the host page's localStorage. localStorage in a content script belongs to whatever site
@@ -116,25 +98,27 @@ const stopHedgehog = () => {
 };
 
 const updateConfig = (config) => {
-  if (!actor) return;
-  actor.updateOptions(toActorOptions(config));
-  // Reload the sprite so a skin change shows immediately, even when AI is off and
-  // the engine wouldn't otherwise re-render the actor.
+  // Route through the state manager (not actor.updateOptions) so friend hedgehogs get
+  // spawned/removed too — not just the player's own skin/colour/accessories.
+  if (!game?.stateManager) return;
+  game.stateManager.setHedgehog({
+    id: "player",
+    player: true,
+    ...toActorOptions(config),
+  });
+  // Reload the sprite so a skin change shows immediately, even when AI is off and the
+  // engine wouldn't otherwise re-render the player.
+  const player = game.getPlayableHedgehog();
   try {
-    actor.updateSprite(actor.currentSprite ?? "idle");
+    player?.updateSprite(player.currentSprite ?? "idle");
   } catch {
-    actor.updateSprite("idle");
+    player?.updateSprite("idle");
   }
 };
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  if (message.type === "UPDATE_CONFIG") {
-    updateConfig(message.config);
-    persistConfig(message.config);
-    sendResponse({ success: true });
-    return true;
-  }
-
+  // Config changes flow through chrome.storage.sync now (see the popup + onChanged below),
+  // so there's no UPDATE_CONFIG message — every tab reacts to the storage event instead.
   if (message.type === "GET_STATUS") {
     sendResponse({ config: actor ? fromActorOptions(actor.options) : null });
     return true;
@@ -170,9 +154,7 @@ chrome.storage.onChanged.addListener((changes, area) => {
   if (changes.hedgehogConfig) {
     // Record what's now in storage so our own onStateChange doesn't echo it straight back.
     lastConfigJson = JSON.stringify(changes.hedgehogConfig.newValue ?? null);
-    if (actor) {
-      updateConfig(changes.hedgehogConfig.newValue || {});
-    }
+    updateConfig(changes.hedgehogConfig.newValue || {});
   }
   if (changes.hedgehogEnabled || changes.disabledSites) {
     reconcileState();

--- a/hedgehog-mode-anywhere/src/content.jsx
+++ b/hedgehog-mode-anywhere/src/content.jsx
@@ -47,6 +47,10 @@ const persistConfig = (config) => {
 let root = null;
 let game = null;
 let actor = null;
+// The freshest config seen before the engine finished starting up. A cross-tab edit can land
+// after render() but before onGameReady (and before GameStateManager exists); we buffer it here
+// instead of dropping it, and flush it once the engine is ready. See updateConfig / onGameReady.
+let pendingConfig = null;
 
 const startHedgehog = (config) => {
   if (root) return;
@@ -78,12 +82,23 @@ const startHedgehog = (config) => {
         },
         // Persist state changes (incl. in-page customization) to chrome.storage instead of
         // the page's localStorage, so they survive navigation and sync across windows.
-        onStateChange: (state) =>
-          persistConfig(fromActorOptions(state.options)),
+        onStateChange: (state) => {
+          // If a newer config arrived during startup, the engine is seeding from a now-stale
+          // `state` prop — skip persisting it so we don't clobber the pending edit. The flush
+          // in onGameReady applies (and persists) the newer config instead.
+          if (pendingConfig !== null) return;
+          persistConfig(fromActorOptions(state.options));
+        },
       }}
       onGameReady={(readyGame) => {
         game = readyGame;
         actor = game.getPlayableHedgehog();
+        // Apply any config that landed while the engine was still starting up.
+        if (pendingConfig !== null) {
+          const config = pendingConfig;
+          pendingConfig = null;
+          updateConfig(config);
+        }
       }}
     />
   );
@@ -100,7 +115,11 @@ const stopHedgehog = () => {
 const updateConfig = (config) => {
   // Route through the state manager (not actor.updateOptions) so friend hedgehogs get
   // spawned/removed too — not just the player's own skin/colour/accessories.
-  if (!game?.stateManager) return;
+  if (!game?.stateManager) {
+    // Engine isn't ready yet — remember the latest config and apply it in onGameReady.
+    pendingConfig = config;
+    return;
+  }
   game.stateManager.setHedgehog({
     id: "player",
     player: true,
@@ -152,9 +171,14 @@ const reconcileState = () => {
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area !== "sync") return;
   if (changes.hedgehogConfig) {
-    // Record what's now in storage so our own onStateChange doesn't echo it straight back.
-    lastConfigJson = JSON.stringify(changes.hedgehogConfig.newValue ?? null);
-    updateConfig(changes.hedgehogConfig.newValue || {});
+    const json = JSON.stringify(changes.hedgehogConfig.newValue ?? null);
+    // Skip events that just echo the config we already hold: a local edit already updated the
+    // engine, and its own storage write comes back here — re-running the full actor/friend
+    // update and sprite refresh would be wasted work. Only genuine cross-tab changes differ.
+    if (json !== lastConfigJson) {
+      lastConfigJson = json;
+      updateConfig(changes.hedgehogConfig.newValue || {});
+    }
   }
   if (changes.hedgehogEnabled || changes.disabledSites) {
     reconcileState();

--- a/hedgehog-mode-anywhere/src/content.jsx
+++ b/hedgehog-mode-anywhere/src/content.jsx
@@ -19,6 +19,12 @@ loadTextures.config.preferWorkers = false;
 const PLATFORM_SELECTOR =
   'button, input, select, .btn, [role="button"], nav, header, footer, aside, .card, .modal, .dialog';
 
+// Ignore elements in the top strip of the viewport when discovering platforms. Sticky
+// headers and nav bars sit at y≈0, and a hedgehog perched on one ends up jammed against
+// the top edge of the window where he's clipped and effectively invisible. Keep his world
+// starting a bit below the fold. (See HedgehogModeConfig.platforms.viewportPadding.)
+const PLATFORM_TOP_INSET = 100;
+
 // Stored config keys map onto the library's HedgehogActorOptions.
 const toActorOptions = (config = {}) => ({
   skin: config.skin || "default",
@@ -38,12 +44,34 @@ const fromActorOptions = (options) => ({
   controls_enabled: options.controls_enabled ?? true,
 });
 
+// The engine persists its state through chrome.storage.sync (below) instead of writing to
+// the host page's localStorage. localStorage in a content script belongs to whatever site
+// you're on: it's per-origin (your hedgehog would reset on every different domain), it
+// litters every page with our key, and it can't sync across windows, sessions or devices.
+// chrome.storage.sync is shared by every tab and window, survives restarts, and roams across
+// the user's signed-in browsers. We store the same flattened `hedgehogConfig` the popup uses,
+// so in-page customization and the popup stay in lockstep.
+let lastConfigJson = null;
+
+const persistConfig = (config) => {
+  const json = JSON.stringify(config);
+  // Skip no-op writes (e.g. the engine re-persisting the state we just seeded it with) so we
+  // don't burn chrome.storage.sync's write quota or fire redundant storage events.
+  if (json === lastConfigJson) return;
+  lastConfigJson = json;
+  chrome.storage.sync.set({ hedgehogConfig: config });
+};
+
 let root = null;
 let game = null;
 let actor = null;
 
 const startHedgehog = (config) => {
   if (root) return;
+
+  // Baseline for persistConfig's dedupe: normalise the seed the same way the engine will
+  // hand it back via onStateChange, so its initial persist-on-spawn is a genuine no-op.
+  lastConfigJson = JSON.stringify(fromActorOptions(toActorOptions(config)));
 
   const host = document.createElement("div");
   host.id = "hedgehog-mode-anywhere";
@@ -58,11 +86,18 @@ const startHedgehog = (config) => {
     <HedgehogModeRenderer
       config={{
         assetsUrl: chrome.runtime.getURL("assets"),
-        platforms: { selector: PLATFORM_SELECTOR },
+        platforms: {
+          selector: PLATFORM_SELECTOR,
+          viewportPadding: { top: PLATFORM_TOP_INSET },
+        },
         // The engine spawns the player hedgehog itself from this state; we don't spawn one.
         state: {
           options: { id: "player", player: true, ...toActorOptions(config) },
         },
+        // Persist state changes (incl. in-page customization) to chrome.storage instead of
+        // the page's localStorage, so they survive navigation and sync across windows.
+        onStateChange: (state) =>
+          persistConfig(fromActorOptions(state.options)),
       }}
       onGameReady={(readyGame) => {
         game = readyGame;
@@ -95,7 +130,7 @@ const updateConfig = (config) => {
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (message.type === "UPDATE_CONFIG") {
     updateConfig(message.config);
-    chrome.storage.sync.set({ hedgehogConfig: message.config });
+    persistConfig(message.config);
     sendResponse({ success: true });
     return true;
   }
@@ -132,8 +167,12 @@ const reconcileState = () => {
 
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area !== "sync") return;
-  if (changes.hedgehogConfig && actor) {
-    updateConfig(changes.hedgehogConfig.newValue || {});
+  if (changes.hedgehogConfig) {
+    // Record what's now in storage so our own onStateChange doesn't echo it straight back.
+    lastConfigJson = JSON.stringify(changes.hedgehogConfig.newValue ?? null);
+    if (actor) {
+      updateConfig(changes.hedgehogConfig.newValue || {});
+    }
   }
   if (changes.hedgehogEnabled || changes.disabledSites) {
     reconcileState();

--- a/hedgehog-mode-anywhere/src/hedgehog-config.js
+++ b/hedgehog-mode-anywhere/src/hedgehog-config.js
@@ -1,0 +1,38 @@
+// Shared mapping between the extension's stored `hedgehogConfig` (a flat, popup-friendly
+// shape kept in chrome.storage.sync) and the engine's HedgehogActorOptions. Imported by both
+// the content script and the popup so the two can never drift out of sync.
+
+// Defaults for a freshly-installed, never-customised hedgehog.
+export const DEFAULT_CONFIG = {
+  skin: "default",
+  color: null,
+  accessories: [],
+  walking_enabled: true,
+  interactions_enabled: true,
+  controls_enabled: true,
+  friends: [],
+};
+
+// Stored config -> engine actor options. (`walking_enabled` is the engine's `ai_enabled`.)
+export const toActorOptions = (config = {}) => ({
+  skin: config.skin || "default",
+  color: config.color || null,
+  accessories: config.accessories || [],
+  ai_enabled: config.walking_enabled ?? true,
+  interactions_enabled: config.interactions_enabled ?? true,
+  controls_enabled: config.controls_enabled ?? true,
+  friends: config.friends || [],
+});
+
+// Engine actor options -> stored config. Keep the key order fixed and identical to
+// DEFAULT_CONFIG: the content script dedupes storage writes by JSON-comparing this output,
+// so a stable serialization keeps round-trips from looking like changes.
+export const fromActorOptions = (options = {}) => ({
+  skin: options.skin || "default",
+  color: options.color || null,
+  accessories: options.accessories || [],
+  walking_enabled: options.ai_enabled ?? true,
+  interactions_enabled: options.interactions_enabled ?? true,
+  controls_enabled: options.controls_enabled ?? true,
+  friends: options.friends || [],
+});

--- a/hedgehog-mode-anywhere/src/popup.jsx
+++ b/hedgehog-mode-anywhere/src/popup.jsx
@@ -8,7 +8,7 @@
 // All state lives in chrome.storage.sync, shared across every tab, window and session. Editing
 // here writes there; each content script reacts via chrome.storage.onChanged. We also listen for
 // changes so the popup reflects edits made from the in-page panel while it happens to be open.
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {
   HedgehogCustomization,
@@ -61,6 +61,9 @@ function App() {
   const [actorConfig, setActorConfig] = useState(() =>
     toActorConfig(DEFAULT_CONFIG)
   );
+  // JSON of the stored config we last wrote or received, so an onChanged event that just echoes
+  // our own edit doesn't re-render the whole customization grid again.
+  const lastConfigJson = useRef(null);
 
   // Load initial state + the active tab's hostname.
   useEffect(() => {
@@ -69,6 +72,7 @@ function App() {
       (result) => {
         setEnabled(!!result.hedgehogEnabled);
         setDisabledSites(result.disabledSites || []);
+        lastConfigJson.current = JSON.stringify(result.hedgehogConfig ?? null);
         setActorConfig(toActorConfig(result.hedgehogConfig));
       }
     );
@@ -88,7 +92,11 @@ function App() {
         setDisabledSites(changes.disabledSites.newValue || []);
       }
       if (changes.hedgehogConfig) {
-        setActorConfig(toActorConfig(changes.hedgehogConfig.newValue));
+        const json = JSON.stringify(changes.hedgehogConfig.newValue ?? null);
+        if (json !== lastConfigJson.current) {
+          lastConfigJson.current = json;
+          setActorConfig(toActorConfig(changes.hedgehogConfig.newValue));
+        }
       }
     };
     chrome.storage.onChanged.addListener(onChanged);
@@ -97,7 +105,9 @@ function App() {
 
   const saveConfig = (next) => {
     setActorConfig(next);
-    chrome.storage.sync.set({ hedgehogConfig: fromActorOptions(next) });
+    const stored = fromActorOptions(next);
+    lastConfigJson.current = JSON.stringify(stored);
+    chrome.storage.sync.set({ hedgehogConfig: stored });
   };
 
   const toggleEnabled = (value) => {

--- a/hedgehog-mode-anywhere/src/popup.jsx
+++ b/hedgehog-mode-anywhere/src/popup.jsx
@@ -1,274 +1,168 @@
-// Popup: customization UI. Option lists and previews come straight from
-// @posthog/hedgehog-mode so they stay in sync with the engine the content script runs.
+// Popup: the extension's control panel. The hedgehog customization grid IS the library's own
+// HedgehogCustomization component — the very same one the in-page "Customize me!" panel uses —
+// wrapped in HedgehogModeRendererContent so it inherits the engine's shadow-root styles. The
+// controls that aren't hedgehog customization (global enable, per-site disable, and the
+// click/drag "Interact with elements" switch the library UI doesn't expose) live in the shell
+// around it.
+//
+// All state lives in chrome.storage.sync, shared across every tab, window and session. Editing
+// here writes there; each content script reacts via chrome.storage.onChanged. We also listen for
+// changes so the popup reflects edits made from the in-page panel while it happens to be open.
+import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import {
-  StaticHedgehog,
-  HedgehogActorSkinOptions,
-  HedgehogActorColorOptions,
-  HedgehogActorAccessories,
+  HedgehogCustomization,
+  HedgehogModeRendererContent,
 } from "@posthog/hedgehog-mode";
+import {
+  DEFAULT_CONFIG,
+  toActorOptions,
+  fromActorOptions,
+} from "./hedgehog-config";
 
 const ASSETS_URL = chrome.runtime.getURL("assets");
 
-const NONE = "__none__";
-
-const prettify = (id) =>
-  id.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-
-// Skins first (no colour), then colour variants of the default skin — mirrors the original grid.
-const SKINS_AND_COLORS = [
-  ...HedgehogActorSkinOptions.map((skin) => ({
-    id: skin,
-    skin,
-    color: null,
-    name: prettify(skin),
-  })),
-  ...HedgehogActorColorOptions.map((color) => ({
-    id: color,
-    skin: "default",
-    color,
-    name: prettify(color),
-  })),
-];
-
-const accessoriesInGroup = (group) =>
-  Object.keys(HedgehogActorAccessories).filter(
-    (key) => HedgehogActorAccessories[key].group === group
-  );
-
-const ACCESSORY_GROUPS = [
-  { group: "headwear", gridId: "headwearGrid" },
-  { group: "eyewear", gridId: "eyewearGrid" },
-  { group: "other", gridId: "otherGrid" },
-].map((g) => ({ ...g, ids: accessoriesInGroup(g.group) }));
-
-let currentConfig = {
-  skin: "default",
-  color: null,
-  accessories: [],
-  walking_enabled: true,
-  interactions_enabled: true,
-  controls_enabled: true,
+const hostnameOf = (url) => {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return null;
+  }
 };
 
-// Render a StaticHedgehog into a container, reusing its React root across updates.
-const staticRoots = new WeakMap();
-function renderStatic(container, options) {
-  let root = staticRoots.get(container);
-  if (!root) {
-    root = createRoot(container);
-    staticRoots.set(container, root);
-  }
-  root.render(
-    <StaticHedgehog options={options} assetsUrl={ASSETS_URL} size="100%" />
-  );
-}
-
-function getCurrentSkinColorId() {
-  if (currentConfig.skin && currentConfig.skin !== "default")
-    return currentConfig.skin;
-  return currentConfig.color || "default";
-}
-
-function createPreviewButton(options, title) {
-  const btn = document.createElement("button");
-  btn.className = "preview-btn";
-  btn.title = title;
-  btn.setAttribute("aria-label", title);
-  btn.setAttribute("aria-pressed", "false");
-
-  const container = document.createElement("div");
-  container.className = "sprite-container";
-  btn.appendChild(container);
-  renderStatic(container, options);
-  return btn;
-}
-
-function initSkinsGrid() {
-  const container = document.getElementById("skinsGrid");
-  SKINS_AND_COLORS.forEach((item) => {
-    const btn = createPreviewButton(
-      { skin: item.skin, color: item.color, accessories: [] },
-      item.name
-    );
-    btn.dataset.skinColor = item.id;
-    btn.addEventListener("click", () => selectSkinColor(item));
-    container.appendChild(btn);
-  });
-}
-
-function initAccessoryGrid({ gridId, ids }) {
-  const container = document.getElementById(gridId);
-
-  const noneBtn = createPreviewButton(
-    { skin: "default", accessories: [] },
-    "None"
-  );
-  noneBtn.dataset.accessory = NONE;
-  noneBtn.addEventListener("click", () => selectAccessory(NONE, ids));
-  container.appendChild(noneBtn);
-
-  ids.forEach((id) => {
-    const btn = createPreviewButton(
-      { skin: "default", accessories: [id] },
-      prettify(id)
-    );
-    btn.dataset.accessory = id;
-    btn.addEventListener("click", () => selectAccessory(id, ids));
-    container.appendChild(btn);
-  });
-}
-
-function selectSkinColor(item) {
-  currentConfig.skin = item.skin;
-  currentConfig.color = item.color;
-  updateUI();
-  saveAndSendConfig();
-}
-
-function selectAccessory(id, groupIds) {
-  currentConfig.accessories = currentConfig.accessories.filter(
-    (a) => !groupIds.includes(a)
-  );
-  if (id !== NONE) {
-    currentConfig.accessories.push(id);
-  }
-  updateUI();
-  saveAndSendConfig();
-}
-
-function getCurrentAccessory(groupIds) {
-  return currentConfig.accessories.find((a) => groupIds.includes(a)) || NONE;
-}
-
-function updatePreview() {
-  renderStatic(document.getElementById("previewHedgehog"), {
-    skin: currentConfig.skin,
-    color: currentConfig.color,
-    accessories: currentConfig.accessories,
-  });
-}
-
-function updateUI() {
-  const currentSkinColorId = getCurrentSkinColorId();
-  document.querySelectorAll("#skinsGrid .preview-btn").forEach((btn) => {
-    const isActive = btn.dataset.skinColor === currentSkinColorId;
-    btn.classList.toggle("active", isActive);
-    btn.setAttribute("aria-pressed", String(isActive));
-  });
-
-  ACCESSORY_GROUPS.forEach(({ gridId, ids }) => {
-    const current = getCurrentAccessory(ids);
-    document.querySelectorAll(`#${gridId} .preview-btn`).forEach((btn) => {
-      const isActive = btn.dataset.accessory === current;
-      btn.classList.toggle("active", isActive);
-      btn.setAttribute("aria-pressed", String(isActive));
-    });
-  });
-
-  document.getElementById("walkingEnabled").checked =
-    currentConfig.walking_enabled;
-  document.getElementById("interactionsEnabled").checked =
-    currentConfig.interactions_enabled;
-  document.getElementById("controlsEnabled").checked =
-    currentConfig.controls_enabled;
-
-  updatePreview();
-}
-
-function saveAndSendConfig() {
-  chrome.storage.sync.set({ hedgehogConfig: currentConfig });
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    if (tabs[0]) {
-      chrome.tabs
-        .sendMessage(tabs[0].id, {
-          type: "UPDATE_CONFIG",
-          config: currentConfig,
-        })
-        .catch(() => {});
-    }
-  });
-}
-
-function toggleHedgehog(enabled) {
-  // The background service worker watches this flag and injects into open tabs.
-  chrome.storage.sync.set({ hedgehogEnabled: enabled });
-}
-
-function syncLiveConfig() {
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    if (!tabs[0]) return;
-    chrome.tabs.sendMessage(tabs[0].id, { type: "GET_STATUS" }, (response) => {
-      if (chrome.runtime.lastError) return;
-      if (response?.config) {
-        currentConfig = { ...currentConfig, ...response.config };
-        updateUI();
-      }
-    });
-  });
-}
-
-function initSiteToggle() {
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    if (!tabs[0]?.url) return;
-    let hostname;
-    try {
-      hostname = new URL(tabs[0].url).hostname;
-    } catch {
-      return;
-    }
-    if (!hostname) return;
-
-    document.getElementById("siteToggleLabel").textContent =
-      `Disable on ${hostname}`;
-
-    chrome.storage.sync.get(["disabledSites"], (result) => {
-      const disabledSites = result.disabledSites || [];
-      document.getElementById("siteToggle").checked =
-        disabledSites.includes(hostname);
-    });
-
-    document.getElementById("siteToggle").addEventListener("change", (e) => {
-      chrome.storage.sync.get(["disabledSites"], (result) => {
-        let disabledSites = result.disabledSites || [];
-        if (e.target.checked) {
-          if (!disabledSites.includes(hostname)) disabledSites.push(hostname);
-        } else {
-          disabledSites = disabledSites.filter((s) => s !== hostname);
-        }
-        chrome.storage.sync.set({ disabledSites });
-      });
-    });
-  });
-}
-
-document.addEventListener("DOMContentLoaded", () => {
-  initSkinsGrid();
-  ACCESSORY_GROUPS.forEach(initAccessoryGrid);
-  initSiteToggle();
-
-  chrome.storage.sync.get(["hedgehogEnabled", "hedgehogConfig"], (result) => {
-    if (result.hedgehogConfig) {
-      currentConfig = { ...currentConfig, ...result.hedgehogConfig };
-    }
-    document.getElementById("enableToggle").checked =
-      result.hedgehogEnabled || false;
-    updateUI();
-  });
-
-  syncLiveConfig();
-
-  document.getElementById("enableToggle").addEventListener("change", (e) => {
-    toggleHedgehog(e.target.checked);
-  });
-
-  const bindOption = (id, key) => {
-    document.getElementById(id).addEventListener("change", (e) => {
-      currentConfig[key] = e.target.checked;
-      saveAndSendConfig();
-    });
-  };
-  bindOption("walkingEnabled", "walking_enabled");
-  bindOption("interactionsEnabled", "interactions_enabled");
-  bindOption("controlsEnabled", "controls_enabled");
+// The player hedgehog as the engine (and HedgehogCustomization) sees it.
+const toActorConfig = (stored) => ({
+  id: "player",
+  player: true,
+  ...toActorOptions(stored || DEFAULT_CONFIG),
 });
+
+function Toggle({ label, checked, onChange, className = "toggle-pill" }) {
+  return (
+    <label className={className}>
+      <span>{label}</span>
+      <span className="toggle">
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={(e) => onChange(e.target.checked)}
+          aria-label={label}
+        />
+        <span className="toggle-slider" />
+      </span>
+    </label>
+  );
+}
+
+function App() {
+  const [enabled, setEnabled] = useState(false);
+  const [disabledSites, setDisabledSites] = useState([]);
+  const [hostname, setHostname] = useState(null);
+  const [actorConfig, setActorConfig] = useState(() =>
+    toActorConfig(DEFAULT_CONFIG)
+  );
+
+  // Load initial state + the active tab's hostname.
+  useEffect(() => {
+    chrome.storage.sync.get(
+      ["hedgehogEnabled", "hedgehogConfig", "disabledSites"],
+      (result) => {
+        setEnabled(!!result.hedgehogEnabled);
+        setDisabledSites(result.disabledSites || []);
+        setActorConfig(toActorConfig(result.hedgehogConfig));
+      }
+    );
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      setHostname(tabs[0]?.url ? hostnameOf(tabs[0].url) : null);
+    });
+  }, []);
+
+  // Stay in step with edits from other tabs / the in-page panel while the popup is open.
+  useEffect(() => {
+    const onChanged = (changes, area) => {
+      if (area !== "sync") return;
+      if (changes.hedgehogEnabled) {
+        setEnabled(!!changes.hedgehogEnabled.newValue);
+      }
+      if (changes.disabledSites) {
+        setDisabledSites(changes.disabledSites.newValue || []);
+      }
+      if (changes.hedgehogConfig) {
+        setActorConfig(toActorConfig(changes.hedgehogConfig.newValue));
+      }
+    };
+    chrome.storage.onChanged.addListener(onChanged);
+    return () => chrome.storage.onChanged.removeListener(onChanged);
+  }, []);
+
+  const saveConfig = (next) => {
+    setActorConfig(next);
+    chrome.storage.sync.set({ hedgehogConfig: fromActorOptions(next) });
+  };
+
+  const toggleEnabled = (value) => {
+    setEnabled(value);
+    // The background service worker watches this flag and injects into open tabs.
+    chrome.storage.sync.set({ hedgehogEnabled: value });
+  };
+
+  const toggleSiteDisabled = (disabled) => {
+    if (!hostname) return;
+    const next = disabled
+      ? [...new Set([...disabledSites, hostname])]
+      : disabledSites.filter((s) => s !== hostname);
+    setDisabledSites(next);
+    chrome.storage.sync.set({ disabledSites: next });
+  };
+
+  const siteDisabled = !!hostname && disabledSites.includes(hostname);
+
+  return (
+    <>
+      <div className="header">
+        <h1>Hedgehog mode</h1>
+      </div>
+
+      <div className="top-toggles">
+        <Toggle
+          label="Enabled hedgehog mode"
+          checked={enabled}
+          onChange={toggleEnabled}
+        />
+        <Toggle
+          label={hostname ? `Disable on ${hostname}` : "Disable on this site"}
+          checked={siteDisabled}
+          onChange={toggleSiteDisabled}
+        />
+      </div>
+
+      <div className="options-toggles">
+        <Toggle
+          className="option-toggle"
+          label="Interact with elements"
+          checked={actorConfig.interactions_enabled ?? true}
+          onChange={(v) =>
+            saveConfig({ ...actorConfig, interactions_enabled: v })
+          }
+        />
+      </div>
+
+      <HedgehogModeRendererContent id="hedgehog-customization" theme="dark">
+        <HedgehogCustomization
+          config={actorConfig}
+          setConfig={saveConfig}
+          assetsUrl={ASSETS_URL}
+        />
+      </HedgehogModeRendererContent>
+
+      <div className="footer">
+        Made with love by{" "}
+        <a href="https://posthog.com" target="_blank" rel="noreferrer">
+          PostHog
+        </a>
+      </div>
+    </>
+  );
+}
+
+createRoot(document.getElementById("root")).render(<App />);

--- a/hedgehog-mode/package.json
+++ b/hedgehog-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@posthog/hedgehog-mode",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "hedgehog mode",
   "license": "MIT",
   "author": "Ben White",

--- a/hedgehog-mode/src/state.ts
+++ b/hedgehog-mode/src/state.ts
@@ -75,12 +75,31 @@ export class GameStateManager {
 
   private persistState() {
     this.config.state = this.state;
-    localStorage.setItem("@hedgehog-mode/state", JSON.stringify(this.state));
+    if (this.config.onStateChange) {
+      // Host owns persistence (e.g. a browser extension backing this with
+      // chrome.storage). Don't also write to the page's localStorage.
+      this.config.onStateChange(this.state);
+      return;
+    }
+    try {
+      localStorage.setItem("@hedgehog-mode/state", JSON.stringify(this.state));
+    } catch {
+      // Storage unavailable (private mode, blocked, SSR) — degrade gracefully.
+    }
   }
 
   private getPersistedState() {
-    const state = localStorage.getItem("@hedgehog-mode/state");
-    return state ? JSON.parse(state) : null;
+    // When the host owns persistence it also supplies the initial state via
+    // config.state; never fall back to the host page's localStorage.
+    if (this.config.onStateChange) {
+      return null;
+    }
+    try {
+      const state = localStorage.getItem("@hedgehog-mode/state");
+      return state ? JSON.parse(state) : null;
+    } catch {
+      return null;
+    }
   }
 
   private upsertHedgehog(config: HedgehogActorOptions) {

--- a/hedgehog-mode/src/types.ts
+++ b/hedgehog-mode/src/types.ts
@@ -53,6 +53,13 @@ export type HedgehogModeConfig = {
     syncFrequency?: number;
   };
   state?: HedgehogModeGameState;
+  // Called whenever the engine persists its state (initial spawn, in-app
+  // customization, friends changing). When provided, the engine hands persistence
+  // entirely to the host and does NOT touch localStorage — pair it with `state` for
+  // the initial value. Browser extensions use this to store state in chrome.storage,
+  // which (unlike the host page's per-origin localStorage) survives navigation across
+  // origins and syncs across windows, sessions and even devices.
+  onStateChange?: (state: HedgehogModeGameState) => void;
   onQuit?: (game: HedgehogModeInterface) => void;
 };
 

--- a/hedgehog-mode/src/ui/GameUI.tsx
+++ b/hedgehog-mode/src/ui/GameUI.tsx
@@ -233,7 +233,7 @@ export function HedgehogModeUI({ game }: { game: HedgeHogMode }) {
         <div className="DialogBoxContent">
           {showConfiguration && actorOptions && (
             <HedgehogCustomization
-              game={game}
+              assetsUrl={game.options.assetsUrl}
               config={actorOptions}
               setConfig={(config) => {
                 setActorOptions(config);

--- a/hedgehog-mode/src/ui/components/Customization.tsx
+++ b/hedgehog-mode/src/ui/components/Customization.tsx
@@ -95,7 +95,10 @@ export function HedgehogCustomization({
     return selectedFriendId
       ? (config.friends?.find((f) => f.id === selectedFriendId) ?? null)
       : null;
-  }, [selectedFriendId]);
+    // Depend on config.friends too: editing the selected friend's skin/color/accessories
+    // replaces its entry, and without this the controls keep showing the old values until
+    // another friend is selected.
+  }, [selectedFriendId, config.friends]);
 
   const selectedConfig = selectedFriend ?? config;
 

--- a/hedgehog-mode/src/ui/components/Customization.tsx
+++ b/hedgehog-mode/src/ui/components/Customization.tsx
@@ -1,4 +1,7 @@
 import React, { useMemo, useState } from "react";
+// Import config values/types directly (not via the package index) so consumers that only
+// want this customization UI — e.g. the browser extension's popup — don't drag the whole
+// pixi/matter engine into their bundle just to render some sprite grids.
 import {
   getRandomAccessoryCombo,
   HedgehogActorAccessories,
@@ -7,8 +10,8 @@ import {
   HedgehogActorColorOptions,
   HedgehogActorOptions,
   HedgehogActorSkinOptions,
-  HedgeHogMode,
-} from "../..";
+} from "../../actors/hedgehog/config";
+import type { HedgeHogMode } from "../../hedgehog-mode";
 import { HedgehogProfileImage } from "../HedgehogStatic";
 import { Button, IconX } from "./Button";
 import { sample } from "lodash";
@@ -19,7 +22,7 @@ const ACCESSORY_GROUPS = ["headwear", "eyewear", "other"] as const;
 type HedgehogOptionsProps = {
   config: HedgehogActorOptions;
   setConfig: (config: HedgehogActorOptions) => void;
-  game: HedgeHogMode;
+  assetsUrl: string;
 };
 
 function Switch({
@@ -46,14 +49,27 @@ function Switch({
 }
 
 export function HedgehogCustomization({
+  assetsUrl,
   game,
   config,
   setConfig,
   defaultFriend,
-}: HedgehogOptionsProps & {
-  game: HedgeHogMode;
+}: {
+  config: HedgehogActorOptions;
+  setConfig: (config: HedgehogActorOptions) => void;
+  // Where the sprite sheet lives. Pass this directly — a running engine isn't needed to
+  // render the customization UI.
+  assetsUrl?: string;
+  /**
+   * @deprecated Pass `assetsUrl` instead. Only `game.options.assetsUrl` was ever read,
+   * and requiring a full engine instance stopped this UI being reused outside the game
+   * (e.g. in the extension popup). Still accepted so existing callers keep working.
+   */
+  game?: HedgeHogMode;
   defaultFriend?: HedgehogActorOptions | null;
 }) {
+  const resolvedAssetsUrl = assetsUrl ?? game?.options.assetsUrl ?? "";
+
   const [selectedFriendId, setSelectedFriendId] = useState<
     HedgehogActorOptions["id"] | null
   >(defaultFriend?.id ?? null);
@@ -89,7 +105,7 @@ export function HedgehogCustomization({
         <HedgehogProfileImage
           {...config}
           size={100}
-          assetsUrl={game.options.assetsUrl}
+          assetsUrl={resolvedAssetsUrl}
         />
         <div className="CustomizationContent">
           <h3 className="CustomizationTitle">
@@ -130,26 +146,30 @@ export function HedgehogCustomization({
       </div>
 
       <div className="CustomizationOptions">
-        <HedgehogOptions game={game} config={config} setConfig={setConfig} />
+        <HedgehogOptions
+          assetsUrl={resolvedAssetsUrl}
+          config={config}
+          setConfig={setConfig}
+        />
         <HedgehogFriends
-          game={game}
+          assetsUrl={resolvedAssetsUrl}
           config={config}
           setConfig={setConfig}
           setSelectedFriend={(f) => setSelectedFriendId(f?.id ?? null)}
           selectedFriend={selectedFriend}
         />
         <HedgehogColor
-          game={game}
+          assetsUrl={resolvedAssetsUrl}
           color={selectedConfig?.color}
           setColor={(color) => updateCustomization({ color })}
         />
         <HedgehogAccessories
-          game={game}
+          assetsUrl={resolvedAssetsUrl}
           accessories={selectedConfig?.accessories ?? []}
           setAccessories={(accessories) => updateCustomization({ accessories })}
         />
         <HedgehogSkins
-          game={game}
+          assetsUrl={resolvedAssetsUrl}
           skin={selectedConfig?.skin}
           setSkin={(skin) => updateCustomization({ skin })}
         />
@@ -193,7 +213,7 @@ function HedgehogOptions({ config, setConfig }: HedgehogOptionsProps) {
 function HedgehogFriends({
   config,
   setConfig,
-  game,
+  assetsUrl,
   setSelectedFriend,
   selectedFriend,
 }: HedgehogOptionsProps & {
@@ -257,7 +277,7 @@ function HedgehogFriends({
                   key={friend.id}
                   {...friend}
                   size={64}
-                  assetsUrl={game.options.assetsUrl}
+                  assetsUrl={assetsUrl}
                 />
               </Button>
             </div>
@@ -269,11 +289,11 @@ function HedgehogFriends({
 }
 
 function HedgehogAccessories({
-  game,
+  assetsUrl,
   accessories,
   setAccessories,
 }: {
-  game: HedgeHogMode;
+  assetsUrl: string;
   accessories: HedgehogActorAccessoryOption[];
   setAccessories: (accessories: HedgehogActorAccessoryOption[]) => void;
 }) {
@@ -314,7 +334,7 @@ function HedgehogAccessories({
                 <HedgehogProfileImage
                   size={64}
                   accessories={[acc]}
-                  assetsUrl={game.options.assetsUrl}
+                  assetsUrl={assetsUrl}
                 />
               </Button>
             ))}
@@ -326,11 +346,11 @@ function HedgehogAccessories({
 }
 
 function HedgehogSkins({
-  game,
+  assetsUrl,
   skin,
   setSkin,
 }: {
-  game: HedgeHogMode;
+  assetsUrl: string;
   skin: HedgehogActorOptions["skin"];
   setSkin: (skin: HedgehogActorOptions["skin"]) => void;
 }) {
@@ -348,7 +368,7 @@ function HedgehogSkins({
             <HedgehogProfileImage
               size={64}
               skin={option as HedgehogActorOptions["skin"]}
-              assetsUrl={game.options.assetsUrl}
+              assetsUrl={assetsUrl}
             />
           </Button>
         ))}
@@ -358,11 +378,11 @@ function HedgehogSkins({
 }
 
 function HedgehogColor({
-  game,
+  assetsUrl,
   color,
   setColor,
 }: {
-  game: HedgeHogMode;
+  assetsUrl: string;
   color: HedgehogActorOptions["color"];
   setColor: (color: HedgehogActorOptions["color"]) => void;
 }) {
@@ -386,7 +406,7 @@ function HedgehogColor({
             <HedgehogProfileImage
               size={64}
               color={option as HedgehogActorOptions["color"]}
-              assetsUrl={game.options.assetsUrl}
+              assetsUrl={assetsUrl}
             />
           </Button>
         ))}

--- a/playground/app/config/page.tsx
+++ b/playground/app/config/page.tsx
@@ -5,11 +5,10 @@ import {
   getRandomAccessoryCombo,
   HedgehogActorColorOptions,
   HedgehogCustomization,
-  HedgeHogMode,
   HedgehogModeRendererContent,
 } from "@posthog/hedgehog-mode";
 import { sample } from "lodash";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export default function StaticRendering() {
   const [config, setConfig] = useState<HedgehogActorOptions>({
@@ -18,25 +17,16 @@ export default function StaticRendering() {
     color: sample(HedgehogActorColorOptions),
     skin: sample(["default", "spiderhog", "robohog"]),
   });
-  const [game, setGame] = useState<HedgeHogMode | null>(null);
-  useEffect(() => {
-    const game = new HedgeHogMode({
-      assetsUrl: "/assets",
-    });
-    setGame(game);
-  }, []);
 
   return (
     <div className="flex flex-col gap-2 justify-start p-4">
       <div className="flex flex-wrap gap-2 border border-gray-200 rounded-md p-3 bg-white max-w-screen-lg">
         <HedgehogModeRendererContent id="hedgehog-mode">
-          {game && (
-            <HedgehogCustomization
-              config={config}
-              setConfig={setConfig}
-              game={game}
-            />
-          )}
+          <HedgehogCustomization
+            config={config}
+            setConfig={setConfig}
+            assetsUrl="/assets"
+          />
         </HedgehogModeRendererContent>
       </div>
     </div>


### PR DESCRIPTION
## the hedgehog has notes on his living arrangements

Complaints from the little guy, now addressed.

### 🧗 stop stranding him on the ceiling

Platform discovery happily turned sticky headers and nav bars — which live at
`y ≈ 0` — into things to stand on. So he'd climb up, perch on your navbar, and
promptly get clipped against the very top edge of the window, where he is both
present and completely invisible. Peak hide-and-seek.

The engine already supports a `platforms.viewportPadding` inset; the extension
just never used it. Now it ignores the top **100px** of the viewport when
finding platforms, so his world starts a comfortable distance below the fold.

### 💾 stop scribbling his diary on every website he visits

The engine persisted its state with `localStorage`. In a content script that's
the **host page's** `localStorage`: per-origin (your accessorised hog reset
himself on every new domain), scribbled across every page, and unable to sync
across windows or sessions — the whole point of the extension remembering him.

The extension already keeps its popup config in `chrome.storage.sync` — shared
across every tab/window, surviving restarts, roaming across signed-in browsers —
so now the engine writes there too. To make that possible without dragging
`chrome` into the library, `HedgehogModeConfig` gained an optional `onStateChange`
hook: when set, the engine hands persistence to the host and leaves `localStorage`
alone; when omitted it behaves exactly as before, so the PostHog app and
playground are untouched.

### 🎨 one customization UI, not two

The popup had a hand-built grid of skins/colours/accessories that duplicated the
engine's own `HedgehogCustomization` panel — two implementations to keep in step,
and they'd already started to drift. The popup now renders the **real component**
(wrapped in `HedgehogModeRendererContent` for the engine's shadow-root styles), so
popup and in-page "Customize me!" are the same thing by construction. He also
gets **friends** in the popup now, and they persist and sync just like he does.

To make the component reusable outside a running game, `HedgehogCustomization`
now takes `assetsUrl` directly instead of a whole `HedgeHogMode` (only
`game.options.assetsUrl` was ever read — the playground was literally
constructing an engine just to hand it over). `game` still works but is
deprecated; internal callers pass `assetsUrl`. The extension keeps its
non-customization switches — global enable, per-site disable, and the click/drag
"interactions" toggle — in the shell around it.

### 📓 and wrote it down

Added a *Developing & testing locally* section to the extension's README: the
playground `/config` loop for iterating on the UI without a browser, the watch +
reload-unpacked loop for the extension, and a per-change test checklist (top
inset, persistence/sync, popup ↔ in-page parity), plus the `ctrl+d ×5` debug
renderer tip and how to reset state.

## why

He kept vanishing off the top of the window, his outfit didn't survive a page
navigation, and there were two customization UIs slowly disagreeing with each
other. None of that is a great look for a companion whose entire job is being
visibly, consistently around.

## how it was tested

Built and static-checked; not yet loaded into a live browser (worth a manual
smoke-test before merge — see the new README section):

- `pnpm --dir hedgehog-mode build` — library builds, dts emits, no type errors
- `pnpm --dir playground build` — Next build + TypeScript pass (exercises the new
  `assetsUrl` API on the `/config` page)
- `pnpm --dir hedgehog-mode-anywhere build` — extension `tsc --noEmit` (validates
  `api-contract.ts` against the rebuilt engine types) + esbuild bundle both pass
- `pnpm lint`, `pnpm format`, `pnpm test` — all green

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
