### PR TITLE
fix: stop the AI steering the hog mid-air, and round out the web strand

### DIFF
--- a/hedgehog-mode/src/actors/Hedgehog.ts
+++ b/hedgehog-mode/src/actors/Hedgehog.ts
@@ -104,6 +104,27 @@ export class HedgehogActor extends Actor {
     return !!this.attachedWeb;
   }
 
+  // Nothing solid under him: mid-jump, falling, thrown, or swinging on a web.
+  get isAirborne(): boolean {
+    return !this.getGround();
+  }
+
+  /**
+   * Whether the idle AI is allowed to take an action right now. Mid-air (thrown,
+   * falling, web-swinging) or held in the player's pointer, an AI walk or jump
+   * reads as the hog jinking sideways or double-jumping out of nothing — so the
+   * AI waits until he's back on something solid. Deliberate player input is
+   * still free to steer him in the air; that's the fun bit.
+   */
+  get isSettled(): boolean {
+    return (
+      !this.isDead &&
+      !this.isDragging &&
+      !this.isWebSlinging &&
+      !this.isAirborne
+    );
+  }
+
   // Don't wrap/clamp to the screen edges while tethered — otherwise wrapping
   // teleports the body across the screen and the web tension explodes, flinging
   // him in a loop. Let him swing freely out of frame and back instead.
@@ -328,6 +349,16 @@ export class HedgehogActor extends Actor {
       return;
     }
 
+    const isAirborne = this.isAirborne;
+
+    // A walk intent must not survive leaving the ground unless the player is
+    // actually holding a direction. Otherwise a hog who was mid-stroll when he
+    // got thrown (or slung on a web) keeps having his horizontal velocity
+    // overwritten every frame, which looks like he swerves in mid-flight.
+    if (isAirborne && !this.controls.isSteering) {
+      this.walkSpeed = 0;
+    }
+
     const xForce = this.walkSpeed;
 
     if (!this.isWebSlinging && xForce !== 0) {
@@ -351,7 +382,7 @@ export class HedgehogActor extends Actor {
     }
 
     // Set the appropriate animation
-    if (!this.getGround()) {
+    if (isAirborne) {
       this.updateSprite("fall");
     } else if (Math.abs(this.rigidBody!.velocity.x) > 0.1) {
       // If horizontal movement is noticeable then walk

--- a/hedgehog-mode/src/actors/hedgehog/ai.ts
+++ b/hedgehog-mode/src/actors/hedgehog/ai.ts
@@ -1,6 +1,10 @@
 import { sample } from "../../misc/utils";
 import type { HedgehogActor } from "../Hedgehog";
 
+// How long to wait before looking again when the hog is in no state to act —
+// mid-air, mid-swing, or being dragged around by the player.
+const SETTLE_RETRY_MS = 250;
+
 export class HedgehogActorAI {
   private actionInterval?: NodeJS.Timeout;
   private enabled = false;
@@ -82,10 +86,18 @@ export class HedgehogActorAI {
       return;
     }
 
-    this.actor.walkSpeed = 0;
-
     clearTimeout(this.actionInterval);
     this.actionInterval = undefined;
+
+    // He's off the ground (falling, thrown, swinging) or in the player's grip.
+    // Acting now is what made him suddenly stride or jump in mid-air, so leave
+    // physics alone and check back once he's landed.
+    if (!this.actor.isSettled) {
+      this.pause(SETTLE_RETRY_MS);
+      return;
+    }
+
+    this.actor.walkSpeed = 0;
 
     if (action) {
       this.actions[action]?.act();

--- a/hedgehog-mode/src/actors/hedgehog/controls.ts
+++ b/hedgehog-mode/src/actors/hedgehog/controls.ts
@@ -2,12 +2,23 @@ import { NO_PLATFORM_COLLISION_FILTER } from "../Actor";
 import { HedgehogActor } from "../Hedgehog";
 
 export class HedgehogActorControls {
+  private heldKeys = new Set<string>();
+
   constructor(private actor: HedgehogActor) {
     this.setupKeyboardListeners();
   }
 
+  /**
+   * True while the player is holding exactly one horizontal direction — i.e. the
+   * walk intent belongs to a human, not the idle AI. The actor uses this to
+   * decide whether a walk should keep overriding his velocity in mid-air.
+   */
+  get isSteering(): boolean {
+    return this.heldKeys.has("left") !== this.heldKeys.has("right");
+  }
+
   setupKeyboardListeners(): () => void {
-    const heldKeys = new Set<string>();
+    const heldKeys = this.heldKeys;
 
     const keyMapping = {
       ArrowLeft: "left",

--- a/hedgehog-mode/src/items/SpiderWebActor.ts
+++ b/hedgehog-mode/src/items/SpiderWebActor.ts
@@ -4,7 +4,13 @@ import gsap from "gsap";
 import { HedgehogModeInterface, GameElement, UpdateTicker } from "../types";
 import type { HedgehogActor } from "../actors/Hedgehog";
 
-const NUM_LINKS = 8;
+// Segment count drives how round the strand can look — the silk bends only where
+// there's a joint. Each link is correspondingly small and light so the *total*
+// rope mass (and therefore the swing feel) stays where it was with fewer, longer
+// links.
+const NUM_LINKS = 16;
+const LINK_WIDTH = 4;
+const LINK_HEIGHT = 12;
 // How long the strand stays fully visible after release before it fades.
 const FADE_DELAY_S = 2;
 const FADE_DURATION_S = 1.5;
@@ -13,7 +19,9 @@ const MAX_WEBS = 40;
 
 // Rope feel: springy + damped so the strand flexes instead of snapping rigid.
 const ANCHOR_STIFFNESS = 1; // firmly stuck to the point it grabbed
-const LINK_STIFFNESS = 0.8;
+// More joints in series means more total give, so each one pulls a little harder
+// than it did with half the links — keeps the reel-in tension feeling the same.
+const LINK_STIFFNESS = 0.9;
 const LINK_DAMPING = 0.1;
 const ATTACH_STIFFNESS = 0.6;
 const ATTACH_DAMPING = 0.2;
@@ -25,7 +33,9 @@ const ATTACH_DAMPING = 0.2;
 const SLACK_FACTOR = 0.8;
 // How fast climbing shortens/lengthens the rope (multiplier per second held).
 const CLIMB_PER_SECOND = 2.5;
-const MIN_LINK_LENGTH = 6;
+// Per-link floor, so it's how close to the anchor a full climb gets him: keep it
+// small enough that NUM_LINKS of them still add up to a short rope.
+const MIN_LINK_LENGTH = 3;
 // Descending can extend the rope well past where it started; this just keeps the
 // numbers bounded so a held key can't blow the link lengths up to infinity.
 const MAX_LINK_LENGTH_FLOOR = 400;
@@ -115,8 +125,8 @@ export class SpiderWebActor implements GameElement {
         Bodies.rectangle(
           point.x + (hog.x - point.x) * t,
           point.y + (hog.y - point.y) * t,
-          5,
-          20,
+          LINK_WIDTH,
+          LINK_HEIGHT,
           {
             density: 0.0005,
             frictionAir: 0.02,
@@ -228,10 +238,31 @@ export class SpiderWebActor implements GameElement {
     });
   }
 
+  // Path the strand through the given points as a smooth curve instead of a
+  // polyline: every point becomes the control point of a quadratic that runs
+  // between the midpoints of its neighbours, so each joint rounds off rather than
+  // showing up as a kink. Endpoints (the anchor and the hog's hand) stay exact.
+  private traceStrand(points: Matter.Vector[]): void {
+    const graphics = this.graphics;
+    graphics.moveTo(points[0].x, points[0].y);
+    for (let i = 1; i < points.length - 1; i++) {
+      const next = points[i + 1];
+      graphics.quadraticCurveTo(
+        points[i].x,
+        points[i].y,
+        (points[i].x + next.x) / 2,
+        (points[i].y + next.y) / 2
+      );
+    }
+    const end = points[points.length - 1];
+    graphics.lineTo(end.x, end.y);
+  }
+
   // Silk strand: anchor -> rope body centres -> hog (while attached). Drawn as a
   // dark contrast outline under a crisp white line, with a "stuck" splat at the
   // anchor. Two passes (dark wider, white narrower) keep it readable on both
-  // light and dark backgrounds.
+  // light and dark backgrounds. The joints are smoothed into curves (see
+  // {@link traceStrand}) so the strand hangs rather than zig-zags.
   private draw(): void {
     const alpha = 1 - this.fade;
     const points: Matter.Vector[] = [
@@ -258,15 +289,8 @@ export class SpiderWebActor implements GameElement {
     const graphics = this.graphics;
     graphics.clear();
 
-    const traceStrand = () => {
-      graphics.moveTo(points[0].x, points[0].y);
-      for (let i = 1; i < points.length; i++) {
-        graphics.lineTo(points[i].x, points[i].y);
-      }
-    };
-
     // Dark outline underlay — gives contrast on light backgrounds.
-    traceStrand();
+    this.traceStrand(points);
     graphics.stroke({
       width: 3.5,
       color: OUTLINE_COLOR,
@@ -276,7 +300,7 @@ export class SpiderWebActor implements GameElement {
     });
 
     // Crisp silk strand on top.
-    traceStrand();
+    this.traceStrand(points);
     graphics.stroke({
       width: 1.5,
       color: SILK_COLOR,

--- a/hedgehog-mode/test/ai.test.ts
+++ b/hedgehog-mode/test/ai.test.ts
@@ -1,0 +1,65 @@
+import { HedgehogActorAI } from "../src/actors/hedgehog/ai";
+import type { HedgehogActor } from "../src/actors/Hedgehog";
+
+// The AI only ever pokes at these few members of the actor, so a stub is enough
+// to assert the thing that matters: it keeps its hands off him in mid-air.
+const fakeActor = (isSettled: boolean) => {
+  const actor = {
+    isSettled,
+    walkSpeed: 0,
+    jump: vi.fn<() => void>(),
+    setDirection: vi.fn<() => void>(),
+    updateSprite: vi.fn<() => void>(),
+  };
+  return actor as unknown as HedgehogActor & typeof actor;
+};
+
+const didSomething = (actor: ReturnType<typeof fakeActor>): boolean =>
+  actor.jump.mock.calls.length > 0 ||
+  actor.updateSprite.mock.calls.length > 0 ||
+  actor.walkSpeed !== 0;
+
+describe("hedgehog AI", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("takes no action while the hog is unsettled", () => {
+    const actor = fakeActor(false);
+    new HedgehogActorAI(actor).enable();
+
+    // Plenty of retries — no walking, no jumping, no waving in mid-air.
+    vi.advanceTimersByTime(10000);
+
+    expect(didSomething(actor)).toBe(false);
+  });
+
+  it("acts again once the hog lands", () => {
+    // Pin the weighted action pick to its last entry (walking) so the assertion
+    // doesn't depend on which idle behaviour the dice hand us.
+    vi.spyOn(Math, "random").mockReturnValue(0.99);
+
+    const actor = fakeActor(false);
+    new HedgehogActorAI(actor).enable();
+    vi.advanceTimersByTime(1000);
+    expect(didSomething(actor)).toBe(false);
+
+    actor.isSettled = true;
+    vi.advanceTimersByTime(1000);
+
+    expect(actor.walkSpeed).not.toBe(0);
+  });
+
+  it("ignores an explicitly requested action while unsettled", () => {
+    const actor = fakeActor(false);
+    const ai = new HedgehogActorAI(actor);
+    ai.enable();
+    ai.run("jump");
+
+    expect(actor.jump).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## what

Two things, both about the hog having opinions he wasn't entitled to.

**1. the AI stops backseat-driving mid-air.** The idle AI ran on a dumb timer that
fired whether or not the hedgehog was, y'know, in the air. So you'd throw him, or
sling off a web, and halfway through the arc he'd decide it was a great moment to
go for a stroll — his horizontal velocity overwritten every single frame — or
casually jump off nothing at all. Very "we don't need product feedback, we have
vision."

He now only takes idle actions once he's *settled*: on the ground, not in your
pointer's grip, not swinging. A stale walk intent no longer survives leaving the
ground either, unless you're actually holding a direction — deliberate air
control is the fun bit and stays exactly as it was.

**2. the web is round now.** The strand was 8 chunky links drawn as a polyline,
which is less "silk" and more "seismograph". It's now 16 smaller, lighter links
(total rope mass unchanged, so the swing feels the same) drawn as a quadratic
curve through the joints.

## why

Reported from actual play: the hedgehog randomly jumps or jinks sideways while
falling, especially when spiderhogging or being thrown — and the web looked
angular rather than rope-like.

## how it was tested

`pnpm build`, `pnpm lint`, `pnpm test` all green, plus a new unit test pinning
the AI gate (no acting while unsettled, resumes on landing).

Then measured for real in a headless browser against the playground, same script
before and after — 25 throws, ~1,800 airborne frames, instrumenting every
velocity override and jump applied to the hog while he had no ground under him:

| | before | after |
|---|---|---|
| mid-air velocity overrides | 1007 | **0** |
| mid-air AI jumps | 5 | **0** |
| strand segments | 8 | 16 |
| sharpest kink at a joint (avg / worst) | 30° / 180° | **1.3° / 9.5°** |
| total rope mass | 0.400 | 0.384 |

Also whipped the anchor around mid-swing for a few rounds to make sure the longer
chain doesn't explode: no NaN positions, strands still clean themselves up after
release, and the hog lands and goes back to wandering — which is the AI gate
letting go again.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
